### PR TITLE
feat(antigravity): apply providerOverrides to dynamically fetched models

### DIFF
--- a/src/types/sharedTypes.ts
+++ b/src/types/sharedTypes.ts
@@ -96,6 +96,10 @@ export interface ModelOverride {
      * 如果提供，将在API请求中合并到请求体中
      */
     extraBody?: Record<string, unknown>;
+    /**
+     * 是否在聊天界面显示思考过程（推荐thinking模型启用）
+     */
+    outputThinking?: boolean;
 }
 
 /**

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -407,6 +407,13 @@ export class ConfigManager {
                             `  Model ${modelOverride.id}: Merge extraBody = ${JSON.stringify(existingModel.extraBody)}`
                         );
                     }
+                    // Override outputThinking
+                    if (modelOverride.outputThinking !== undefined) {
+                        existingModel.outputThinking = modelOverride.outputThinking;
+                        Logger.debug(
+                            `  Model ${modelOverride.id}: Override outputThinking = ${modelOverride.outputThinking}`
+                        );
+                    }
                 } else {
                     const fullConfig = modelOverride as ModelConfig;
                     // Add new model
@@ -424,7 +431,10 @@ export class ConfigManager {
                         ...(modelOverride.sdkMode && { sdkMode: modelOverride.sdkMode }),
                         ...(modelOverride.baseUrl && { baseUrl: modelOverride.baseUrl }),
                         ...(modelOverride.customHeader && { customHeader: modelOverride.customHeader }),
-                        ...(modelOverride.extraBody && { extraBody: modelOverride.extraBody })
+                        ...(modelOverride.extraBody && { extraBody: modelOverride.extraBody }),
+                        ...(modelOverride.outputThinking !== undefined && {
+                            outputThinking: modelOverride.outputThinking
+                        })
                     };
                     config.models.push(newModel);
                     Logger.info(`  Add new model: ${modelOverride.id}`);


### PR DESCRIPTION
AntigravityProvider now correctly applies user configuration overrides (extraBody, maxOutputTokens, outputThinking) from settings.json to models fetched dynamically from the Antigravity API.

This enables users to configure thinkingBudget and other parameters for thinking models like Claude Opus 4.5 via chp.providerOverrides.

Changes:
- Add outputThinking field to ModelOverride interface
- Apply extraBody, maxOutputTokens, outputThinking from overrides in AntigravityProvider.provideLanguageModelChatInformation()
- Add outputThinking handling in ConfigManager.applyProviderOverrides()