### PR TITLE
fix(antigravity): backport system instruction fixes for HTTP 429 errors from CLIProxyAPI

### DIFF
--- a/src/providers/antigravity/types.ts
+++ b/src/providers/antigravity/types.ts
@@ -132,7 +132,7 @@ export interface GeminiContent {
 
 export interface GeminiRequest {
     contents: GeminiContent[];
-    systemInstruction?: { parts: { text: string }[] };
+    systemInstruction?: { role?: string; parts: { text: string }[] };
     generationConfig?: {
         maxOutputTokens?: number;
         temperature?: number;
@@ -152,6 +152,7 @@ export interface AntigravityPayload {
     model: string;
     userAgent: string;
     requestId: string;
+    requestType?: string;
     request: GeminiRequest & { sessionId: string };
 }
 


### PR DESCRIPTION
Backport changes from [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) that fix HTTP 429 quota errors by adding specialized system instructions:

- Add Antigravity/Deepmind agentic coding system instruction
- Inject enhanced instruction for Claude and all Gemini 3 models (pro, low, high variants)
- Set systemInstruction.role to 'user' with antigravity-specific prompt
- Add requestType field set to 'agent' for proper request classification
- Update TypeScript interfaces to support role in systemInstruction and requestType

Fixes: HTTP 429 quota/rate permanent limit errors for Claude and Gemini 3 models