### PR TITLE
Fix antigravity provider integration — 404, stream processor, schema sanitization, model filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "copilot-helper-pro",
-    "version": "0.15.22",
+    "version": "0.15.27",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "copilot-helper-pro",
-            "version": "0.15.22",
+            "version": "0.15.27",
             "license": "MIT",
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.67.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "biebie99",
     "displayName": "Copilot Helper Pro",
     "description": "An extension that provides model support for GitHub Copilot Chat, including ZhipuAI, MiniMax, MoonshotAI, DeepSeek, Alibaba Cloud Bailian, and custom OpenAI/Anthropic compatible models.",
-    "version": "0.15.27",
+    "version": "0.16.0",
     "license": "MIT",
     "keywords": [
         "ai",

--- a/src/providers/antigravity/auth.ts
+++ b/src/providers/antigravity/auth.ts
@@ -3,6 +3,7 @@ import { URL, URLSearchParams } from 'url';
 import * as vscode from 'vscode';
 import { configProviders } from '../config';
 import { ApiKeyManager } from '../../utils/apiKeyManager';
+import { Logger } from '../../utils';
 import { TokenResponse, UserInfo, AntigravityAuthResult, AntigravityModel, ModelQuickPickItem } from './types';
 import { ProviderKey } from '../../types/providerKeys';
 
@@ -325,7 +326,22 @@ async function doAntigravityLoginAndSave(isAddingNewAccount: boolean): Promise<v
         refreshToken: result.refreshToken,
         expiresAt: result.expiresAt
     };
+    // Build the key data shared by both paths. Stored BEFORE the account-manager event
+    // fires so that provideLanguageModelChatInformation already sees the filtered model list.
+    const keyData = JSON.stringify({
+        type: PROVIDER_KEY,
+        access_token: result.accessToken,
+        refresh_token: result.refreshToken,
+        email: result.email,
+        project_id: result.projectId,
+        expires_at: result.expiresAt,
+        timestamp: Date.now(),
+        models: models
+    });
     if (existingByEmail && !isAddingNewAccount) {
+        // Credential refresh for an existing account: persist key BEFORE updateCredentials
+        // so the account-change event sees the latest filtered model list.
+        await ApiKeyManager.setApiKey(PROVIDER_KEY, keyData);
         await accountManager.updateCredentials(existingByEmail.id, credentials);
     } else {
         const displayName = result.email
@@ -333,24 +349,15 @@ async function doAntigravityLoginAndSave(isAddingNewAccount: boolean): Promise<v
                 ? `${result.email} (${existingAccounts.length + 1})`
                 : result.email
             : `Antigravity Account ${existingAccounts.length + 1}`;
+        // Save the API key FIRST so that when addOAuthAccount fires the account-change
+        // event, provideLanguageModelChatInformation can already read the filtered model
+        // list from the key store instead of falling back to all hardcoded models.
+        await ApiKeyManager.setApiKey(PROVIDER_KEY, keyData);
         await accountManager.addOAuthAccount(PROVIDER_KEY, displayName, result.email || '', credentials, {
             projectId: result.projectId,
             models: models
         });
     }
-    await ApiKeyManager.setApiKey(
-        PROVIDER_KEY,
-        JSON.stringify({
-            type: PROVIDER_KEY,
-            access_token: result.accessToken,
-            refresh_token: result.refreshToken,
-            email: result.email,
-            project_id: result.projectId,
-            expires_at: result.expiresAt,
-            timestamp: Date.now(),
-            models: models
-        })
-    );
     const message = result.email
         ? `✅ Antigravity login successful! Authenticated as ${result.email}`
         : '✅ Antigravity login successful!';
@@ -358,9 +365,10 @@ async function doAntigravityLoginAndSave(isAddingNewAccount: boolean): Promise<v
     vscode.window.showInformationMessage(
         result.projectId ? `${message} (Project: ${result.projectId})${modelsInfo}` : `${message}${modelsInfo}`
     );
-    if (models.length > 0) {
-        await addAllAntigravityModelsToCompatible(models);
-    }
+    // NOTE: Models are no longer automatically added to the Compatible Provider.
+    // Antigravity models are served exclusively through the native AntigravityProvider,
+    // which prevents users from accidentally editing them as generic OpenAI-compatible entries.
+    Logger.debug(`[Antigravity] Login complete. ${models.length} model(s) available via native provider.`);
 }
 
 export async function antigravityLoginCommand(): Promise<void> {
@@ -534,15 +542,35 @@ export class AntigravityAuth {
             maxOutputTokens: m.maxOutputTokens,
             quotaInfo: undefined
         }));
-        const endpoints = ['daily-cloudcode-pa.sandbox.googleapis.com', 'cloudcode-pa.googleapis.com'];
+        // Priority: daily (non-sandbox) endpoint is most stable per anti-api experience
+        const endpoints = [
+            'daily-cloudcode-pa.googleapis.com',
+            'daily-cloudcode-pa.sandbox.googleapis.com',
+            'cloudcode-pa.googleapis.com'
+        ];
         let quotaMap = new Map<string, { remainingFraction?: number; resetTime?: string }>();
         for (const hostname of endpoints) {
+            Logger.debug(`[Antigravity] Fetching quota from ${hostname}`);
             quotaMap = await this.tryFetchQuotaFromEndpoint(accessToken, hostname);
             if (quotaMap.size > 0) {
+                Logger.debug(`[Antigravity] Got ${quotaMap.size} quota entries from ${hostname}`);
                 break;
             }
+            Logger.debug(`[Antigravity] No quota data from ${hostname}, trying next`);
         }
-        return hardcodedModels.map(model => ({ ...model, quotaInfo: quotaMap.get(model.id.toLowerCase()) }));
+        // When the API returned a non-empty model list, filter to only available models.
+        // Fall back to all hardcoded models when the quota fetch failed (quotaMap empty).
+        const availableModels = quotaMap.size > 0
+            ? hardcodedModels.filter(m => quotaMap.has(m.id.toLowerCase()))
+            : hardcodedModels;
+        if (quotaMap.size > 0) {
+            const hiddenCount = hardcodedModels.length - availableModels.length;
+            Logger.debug(`[Antigravity] Available models for this account: ${availableModels.map(m => m.id).join(', ')}`);
+            if (hiddenCount > 0) {
+                Logger.debug(`[Antigravity] Hiding ${hiddenCount} model(s) not returned by fetchAvailableModels`);
+            }
+        }
+        return availableModels.map(model => ({ ...model, quotaInfo: quotaMap.get(model.id.toLowerCase()) }));
     }
 
     private static async tryFetchQuotaFromEndpoint(
@@ -573,10 +601,12 @@ export class AntigravityAuth {
             for (const originalName of Object.keys(data.models)) {
                 const aliasName = modelName2Alias(originalName);
                 const modelData = data.models[originalName];
-                if (aliasName && modelData?.quotaInfo) {
+                // Track ALL models present in the API response, not just those with quotaInfo.
+                // Presence in the map signals that the model exists for this account.
+                if (aliasName) {
                     quotaMap.set(aliasName.toLowerCase(), {
-                        remainingFraction: modelData.quotaInfo.remainingFraction,
-                        resetTime: modelData.quotaInfo.resetTime
+                        remainingFraction: modelData.quotaInfo?.remainingFraction,
+                        resetTime: modelData.quotaInfo?.resetTime
                     });
                 }
             }
@@ -600,7 +630,15 @@ export class AntigravityAuth {
             const authData = JSON.parse(stored) as { models?: AntigravityModel[] };
             const cachedModels = authData.models || [];
             const antigravityConfig = configProviders[PROVIDER_KEY];
-            return antigravityConfig.models.map(m => {
+            // Filter config models to only those present in the stored list.
+            // fetchModels() applies quota-based filtering before storing, so cached
+            // models already represent what the API reported as available for this account.
+            // Fallback: if nothing is cached yet, show all config models.
+            const cachedIds = new Set(cachedModels.map(cm => cm.id.toLowerCase()));
+            const configModels = cachedIds.size > 0
+                ? antigravityConfig.models.filter(m => cachedIds.has(m.id.toLowerCase()))
+                : antigravityConfig.models;
+            return configModels.map(m => {
                 const cached = cachedModels.find(cm => cm.id.toLowerCase() === m.id.toLowerCase());
                 return {
                     id: m.id,

--- a/src/providers/antigravity/handler.ts
+++ b/src/providers/antigravity/handler.ts
@@ -3,17 +3,33 @@ import * as vscode from 'vscode';
 import { AccountQuotaCache } from '../../accounts/accountQuotaCache';
 import type { ModelConfig } from '../../types/sharedTypes';
 import { ConfigManager } from '../../utils/configManager';
+import { Logger } from '../../utils';
 import { QuotaNotificationManager } from '../../utils/quotaNotificationManager';
 import { OpenAIStreamProcessor } from '../openai/openaiStreamProcessor';
 import { AntigravityAuth } from './auth';
 import { AntigravityStreamProcessor } from './streamProcessor';
 import { ErrorCategory, RateLimitAction, QuotaState, GeminiContent, AntigravityPayload, GeminiRequest } from './types';
 
+/**
+ * Thrown when a stream error occurs AFTER the HTTP 200 response has been received.
+ * Prevents the URL-fallback retry loop from sending a second request to another endpoint,
+ * which would replay tool calls and cause duplicates in the Copilot UI.
+ */
+export class StreamingStartedError extends Error {
+    constructor(cause: unknown) {
+        super(cause instanceof Error ? cause.message : String(cause));
+        this.name = 'StreamingStartedError';
+    }
+}
+
+// URL priority: daily (non-sandbox) is the most stable and up-to-date endpoint.
+// Sandbox is a fallback, production non-daily is last resort.
 export const DEFAULT_BASE_URLS = [
+    'https://daily-cloudcode-pa.googleapis.com',
     'https://daily-cloudcode-pa.sandbox.googleapis.com',
     'https://cloudcode-pa.googleapis.com'
 ];
-export const DEFAULT_USER_AGENT = 'antigravity/1.11.5';
+export const DEFAULT_USER_AGENT = 'antigravity/1.22.2';
 const RATE_LIMIT_MAX_RETRIES = 5;
 const RATE_LIMIT_BASE_DELAY_MS = 1000;
 const RATE_LIMIT_MAX_DELAY_MS = 30000;
@@ -68,7 +84,19 @@ const GEMINI_UNSUPPORTED_FIELDS = new Set([
     'not',
     'strict',
     'input_examples',
-    'examples'
+    'examples',
+    'const',
+    // Additional fields rejected by Gemini v1internal (sourced from anti-api json-schema-cleaner)
+    'enumDescriptions',
+    'enumCaseInsensitive',
+    'enumNormalizeWhitespace',
+    'default',
+    'deprecated',
+    'readOnly',
+    'writeOnly',
+    'format',
+    'cache_control',
+    'propertyNames',
 ]);
 
 const thoughtSignatureStore = new Map<string, string>();
@@ -524,15 +552,30 @@ class MessageConverter {
 class FromIRTranslator {
     private readonly messageConverter = new MessageConverter();
     private readonly MODEL_ALIASES: Record<string, string> = {
+        // Gemini model aliases
         'gemini-2.5-computer-use-preview-10-2025': 'rev19-uic3-1p',
-        'gemini-3-pro-image-preview': 'gemini-3-pro-image',
-        'gemini-3-pro-preview': 'gemini-3-pro-high',
+        'gemini-3.1-pro-image-preview': 'gemini-3.1-pro-image',
+        'gemini-3.1-pro-preview': 'gemini-3.1-pro-high',
+        // Claude Sonnet 4.5
         'gemini-claude-sonnet-4-5': 'claude-sonnet-4-5',
         'claude-sonnet-4-5': 'claude-sonnet-4-5',
+        'claude-sonnet-4.5': 'claude-sonnet-4-5',
+        'claude-sonnet-4-5-20251001': 'claude-sonnet-4-5',
+        // Claude Sonnet 4.5 Thinking
         'gemini-claude-sonnet-4-5-thinking': 'claude-sonnet-4-5-thinking',
         'claude-sonnet-4-5-thinking': 'claude-sonnet-4-5-thinking',
+        'claude-sonnet-4.5-thinking': 'claude-sonnet-4-5-thinking',
+        // Claude Opus 4.5 Thinking
         'gemini-claude-opus-4-5-thinking': 'claude-opus-4-5-thinking',
-        'claude-opus-4-5-thinking': 'claude-opus-4-5-thinking'
+        'claude-opus-4-5-thinking': 'claude-opus-4-5-thinking',
+        'claude-opus-4.5-thinking': 'claude-opus-4-5-thinking',
+        // Claude Opus 4.6 - always maps to thinking variant (same behaviour as anti-api)
+        'claude-opus-4-6': 'claude-opus-4-6-thinking',
+        'claude-opus-4-6-thinking': 'claude-opus-4-6-thinking',
+        'claude-opus-4.6': 'claude-opus-4-6-thinking',
+        'claude-opus-4.6-thinking': 'claude-opus-4-6-thinking',
+        // GPT OSS
+        'gpt-oss-120b': 'gpt-oss-120b-medium'
     };
 
     aliasToModelName(modelName: string): string {
@@ -662,15 +705,18 @@ export class AntigravityHandler {
     ): Promise<void> {
         const authToken = accessToken || (await AntigravityAuth.getAccessToken());
         if (!authToken) {
+            Logger.error('[Antigravity] handleRequest: no auth token, aborting');
             throw new Error('Not logged in to Antigravity. Please login first.');
         }
         const requestModel = modelConfig.model || model.id;
         const resolvedModel = this.fromIRTranslator.aliasToModelName(requestModel);
         const effectiveAccountId = accountId || 'default-antigravity';
         const quotaKey = `${effectiveAccountId}:${resolvedModel}`;
+        Logger.debug(`[Antigravity] handleRequest: model=${resolvedModel} account=${effectiveAccountId} sdkMode=${modelConfig.sdkMode || 'default'}`);
 
         if (this.quotaManager.isInCooldown(quotaKey)) {
             const remaining = this.quotaManager.getRemainingCooldown(quotaKey);
+            Logger.debug(`[Antigravity] Model ${resolvedModel} in quota cooldown, ${remaining}ms remaining`);
             if (remaining > 5000) {
                 this.quotaNotificationManager.notifyQuotaExceeded(
                     remaining,
@@ -719,6 +765,7 @@ export class AntigravityHandler {
         const baseUrls = modelConfig.baseUrl
             ? [modelConfig.baseUrl.replace(/\/v1internal\/?$/, '')]
             : [...DEFAULT_BASE_URLS];
+        Logger.debug(`[Antigravity] Will try ${baseUrls.length} endpoint(s): ${baseUrls.join(', ')}`);
         const abortController = new AbortController();
         const cancelListener = token.onCancellationRequested(() => abortController.abort());
         const retrier = new RateLimitRetrier();
@@ -730,6 +777,7 @@ export class AntigravityHandler {
         try {
             for (let idx = 0; idx < baseUrls.length; idx++) {
                 const url = `${baseUrls[idx].replace(/\/$/, '')}/v1internal:streamGenerateContent?alt=sse`;
+                Logger.debug(`[Antigravity] Attempt ${idx + 1}/${baseUrls.length}: ${url}`);
                 if (token.isCancellationRequested) {
                     throw new vscode.CancellationError();
                 }
@@ -744,6 +792,7 @@ export class AntigravityHandler {
                         abortController
                     );
                     if (result.success) {
+                        Logger.debug(`[Antigravity] Request succeeded on endpoint ${idx + 1}`);
                         this.quotaManager.clearQuotaExceeded(quotaKey);
                         this.quotaNotificationManager.clearQuotaCountdown();
                         this.debouncedCacheUpdate(
@@ -846,6 +895,12 @@ export class AntigravityHandler {
                     if (error instanceof vscode.CancellationError) {
                         throw error;
                     }
+                    // If streaming already started, do NOT retry — replaying the request to another
+                    // endpoint would cause tool calls to be reported twice in the Copilot UI.
+                    if (error instanceof StreamingStartedError) {
+                        Logger.warn('[Antigravity] Stream error after data received — not retrying to prevent tool call duplication');
+                        throw error;
+                    }
                     if (
                         error instanceof Error &&
                         (error.message.startsWith('Quota exceeded') ||
@@ -858,6 +913,7 @@ export class AntigravityHandler {
                     lastStatus = 0;
                     lastBody = '';
                     lastError = error instanceof Error ? error : new Error(String(error));
+                    Logger.debug(`[Antigravity] Endpoint ${idx + 1} threw non-HTTP error: ${lastError.message}`);
                     if (idx + 1 < baseUrls.length) {
                         continue;
                     }
@@ -888,6 +944,8 @@ export class AntigravityHandler {
         abortController: AbortController
     ): Promise<{ success: boolean; status?: number; statusText?: string; body?: string }> {
         let response: Response;
+        Logger.debug(`[Antigravity] streamRequest → POST ${url} (model: ${payload.model})`);
+        const startTime = Date.now();
         try {
             response = await fetch(url, {
                 method: 'POST',
@@ -902,23 +960,41 @@ export class AntigravityHandler {
             });
         } catch (error) {
             if (token.isCancellationRequested || abortController.signal.aborted) {
+                Logger.debug('[Antigravity] streamRequest cancelled by user');
                 throw new vscode.CancellationError();
             }
+            Logger.error('[Antigravity] streamRequest fetch error:', error);
             throw error;
         }
         if (!response.ok) {
+            const body = await response.text();
+            Logger.warn(`[Antigravity] streamRequest HTTP ${response.status} from ${url}: ${body.slice(0, 300)}`);
             return {
                 success: false,
                 status: response.status,
                 statusText: response.statusText,
-                body: await response.text()
+                body
             };
         }
-        if (modelConfig.sdkMode === 'openai' || modelConfig.sdkMode === 'openai-sse') {
-            await new OpenAIStreamProcessor().processStream({ response, modelConfig, progress, token });
-        } else {
-            await new AntigravityStreamProcessor().processStream({ response, modelConfig, progress, token });
+        Logger.debug(`[Antigravity] streamRequest HTTP 200 from ${url} (${Date.now() - startTime}ms), sdkMode: ${modelConfig.sdkMode || 'default→antigravity'}`);
+        // Streaming is about to start — wrap any subsequent errors in StreamingStartedError
+        // so the caller's fallback loop knows NOT to retry (which would replay tool calls).
+        try {
+            if (modelConfig.sdkMode === 'openai' || modelConfig.sdkMode === 'openai-sse') {
+                Logger.debug('[Antigravity] Using OpenAI stream processor');
+                await new OpenAIStreamProcessor().processStream({ response, modelConfig, progress, token });
+            } else {
+                Logger.debug('[Antigravity] Using Antigravity stream processor');
+                await new AntigravityStreamProcessor().processStream({ response, modelConfig, progress, token });
+            }
+        } catch (streamError) {
+            if (streamError instanceof vscode.CancellationError) {
+                throw streamError;
+            }
+            Logger.error('[Antigravity] Stream processing error (will not retry to avoid tool call duplication):', streamError);
+            throw new StreamingStartedError(streamError);
         }
+        Logger.debug(`[Antigravity] streamRequest completed in ${Date.now() - startTime}ms`);
         return { success: true };
     }
 
@@ -931,11 +1007,13 @@ export class AntigravityHandler {
         }
         this.projectIdPromise = AntigravityAuth.ensureProjectId(accessToken)
             .then(projectId => {
+                Logger.debug(`[Antigravity] Project ID resolved: ${projectId ? projectId.substring(0, 20) + '...' : '(empty)'}`);
                 this.projectIdCache = projectId;
                 this.projectIdPromise = null;
                 return projectId;
             })
             .catch(err => {
+                Logger.error('[Antigravity] Failed to resolve project ID:', err);
                 this.projectIdPromise = null;
                 throw err;
             });

--- a/src/providers/antigravity/provider.ts
+++ b/src/providers/antigravity/provider.ts
@@ -103,15 +103,19 @@ export class AntigravityProvider extends GenericModelProvider implements Languag
                 // Find override for this model
                 const override = modelOverrides.find(o => o.id === m.id);
 
+                // sdkMode MUST NOT be 'openai' for Antigravity models: the native Antigravity
+                // endpoint returns Gemini-format SSE, which must be parsed by AntigravityStreamProcessor.
+                // 'anthropic' routes to AntigravityStreamProcessor (else-branch in streamRequest).
                 const baseConfig: ModelConfig = {
                     id: m.id,
                     name: m.displayName || m.name,
                     tooltip: `${m.displayName} - Antigravity`,
                     maxInputTokens: m.maxTokens || 200000,
                     maxOutputTokens: override?.maxOutputTokens || m.maxOutputTokens || 8192,
-                    sdkMode: 'openai' as const,
+                    sdkMode: 'anthropic' as const,
                     capabilities: { toolCalling: true, imageInput: true }
                 };
+                Logger.debug(`[Antigravity] Model config: id=${m.id} sdkMode=anthropic maxOutput=${baseConfig.maxOutputTokens}`);
 
                 // Apply extraBody from override if present
                 if (override?.extraBody) {

--- a/src/providers/antigravity/requestHelpers.ts
+++ b/src/providers/antigravity/requestHelpers.ts
@@ -49,19 +49,46 @@ const GEMINI_UNSUPPORTED_FIELDS = new Set([
     'not',
     'strict',
     'input_examples',
-    'examples'
+    'examples',
+    'const',
+    // Additional fields rejected by Gemini v1internal (sourced from anti-api json-schema-cleaner)
+    'enumDescriptions',
+    'enumCaseInsensitive',
+    'enumNormalizeWhitespace',
+    'default',
+    'deprecated',
+    'readOnly',
+    'writeOnly',
+    'format',
+    'cache_control',
+    'propertyNames',
 ]);
 
 const MODEL_ALIASES: Record<string, string> = {
+    // Gemini model aliases
     'gemini-2.5-computer-use-preview-10-2025': 'rev19-uic3-1p',
-    'gemini-3-pro-image-preview': 'gemini-3-pro-image',
-    'gemini-3-pro-preview': 'gemini-3-pro-high',
+    'gemini-3.1-pro-image-preview': 'gemini-3.1-pro-image',
+    'gemini-3.1-pro-preview': 'gemini-3.1-pro-high',
+    // Claude Sonnet 4.5 - both dash and dot notation
     'gemini-claude-sonnet-4-5': 'claude-sonnet-4-5',
     'claude-sonnet-4-5': 'claude-sonnet-4-5',
+    'claude-sonnet-4.5': 'claude-sonnet-4-5',
+    'claude-sonnet-4-5-20251001': 'claude-sonnet-4-5',
+    // Claude Sonnet 4.5 Thinking
     'gemini-claude-sonnet-4-5-thinking': 'claude-sonnet-4-5-thinking',
     'claude-sonnet-4-5-thinking': 'claude-sonnet-4-5-thinking',
+    'claude-sonnet-4.5-thinking': 'claude-sonnet-4-5-thinking',
+    // Claude Opus 4.5 Thinking
     'gemini-claude-opus-4-5-thinking': 'claude-opus-4-5-thinking',
-    'claude-opus-4-5-thinking': 'claude-opus-4-5-thinking'
+    'claude-opus-4-5-thinking': 'claude-opus-4-5-thinking',
+    'claude-opus-4.5-thinking': 'claude-opus-4-5-thinking',
+    // Claude Opus 4.6 - always maps to the thinking variant (same as anti-api)
+    'claude-opus-4-6': 'claude-opus-4-6-thinking',
+    'claude-opus-4-6-thinking': 'claude-opus-4-6-thinking',
+    'claude-opus-4.6': 'claude-opus-4-6-thinking',
+    'claude-opus-4.6-thinking': 'claude-opus-4-6-thinking',
+    // GPT OSS - the API expects the "medium" suffix
+    'gpt-oss-120b': 'gpt-oss-120b-medium'
 };
 
 export function aliasToModelName(modelName: string): string {

--- a/src/providers/antigravity/streamProcessor.ts
+++ b/src/providers/antigravity/streamProcessor.ts
@@ -2,10 +2,12 @@ import * as vscode from 'vscode';
 import type { ModelConfig } from '../../types/sharedTypes';
 import { ProcessStreamOptions } from '../common/commonTypes';
 import { storeThoughtSignature, extractToolCallFromGeminiResponse } from './handler';
+import { Logger } from '../../utils';
 
 export class AntigravityStreamProcessor {
     private textBuffer = '';
     private textBufferLastFlush = 0;
+    private totalTextEmitted = 0; // tracks total chars emitted as LanguageModelTextPart
     private thinkingBuffer = '';
     private currentThinkingId: string | null = null;
     private seenToolCalls = new Set<string>();
@@ -82,8 +84,35 @@ export class AntigravityStreamProcessor {
         } finally {
             this.stopActivityReporting();
             this.processRemainingBuffer(buffer, modelConfig, progress);
+            // Flush any text held back by the '<thinking>' tag lookahead buffer.
+            if (this.thinkingTagBuffer.length > 0) {
+                Logger.debug(`[Antigravity] Flushing thinkingTagBuffer remainder: ${this.thinkingTagBuffer.length} chars`);
+                this.textBuffer += this.thinkingTagBuffer;
+                this.thinkingTagBuffer = '';
+            }
             this.flushTextBuffer(progress, true);
-            this.flushPendingToolCallsImmediate(progress); // Flush tất cả tool calls còn lại
+            this.flushPendingToolCallsImmediate(progress);
+
+            // If no text at all was emitted during this stream (e.g. GPT OSS 120B returns
+            // its final answer entirely as thought:true parts), convert the accumulated
+            // thinking content into a text response so VS Code does not show
+            // "Sorry, no response was returned."
+            if (this.totalTextEmitted === 0) {
+                if (this.thinkingFlushInterval) {
+                    clearInterval(this.thinkingFlushInterval);
+                    this.thinkingFlushInterval = null;
+                }
+                const pendingThinking = this.thinkingBuffer + this.thinkingQueue;
+                if (pendingThinking.length > 0) {
+                    Logger.debug(`[Antigravity] No text emitted; converting ${pendingThinking.length} chars of thinking to text (thought-only response)`);
+                    this.thinkingBuffer = '';
+                    this.thinkingQueue = '';
+                    this.currentThinkingId = null;
+                    progress.report(new vscode.LanguageModelTextPart(pendingThinking));
+                    return;
+                }
+            }
+
             this.finalizeThinkingPart(progress);
         }
     }
@@ -390,10 +419,12 @@ export class AntigravityStreamProcessor {
             this.textBuffer.length > 0 &&
             (force || this.textBuffer.length >= AntigravityStreamProcessor.TEXT_BUFFER_MIN_SIZE)
         ) {
+            Logger.debug(`[Antigravity] Emitting text token: ${this.textBuffer.length} chars`);
+            this.totalTextEmitted += this.textBuffer.length;
             progress.report(new vscode.LanguageModelTextPart(this.textBuffer));
             this.textBuffer = '';
             this.textBufferLastFlush = Date.now();
-            this.markActivity(); // Đánh dấu activity khi flush
+            this.markActivity();
         }
     }
 

--- a/src/providers/config/antigravity.json
+++ b/src/providers/config/antigravity.json
@@ -1,12 +1,12 @@
 {
     "displayName": "Antigravity (Google Cloud Code)",
-    "baseUrl": "https://api.antigravity.com/v1",
+    "baseUrl": "https://daily-cloudcode-pa.googleapis.com/v1internal",
     "apiKeyTemplate": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "models": [
         {
             "id": "claude-opus-4-5-thinking",
             "name": "Claude Opus 4.5 Thinking",
-            "tooltip": "Claude Opus 4.5 với khả năng suy luận mở rộng",
+            "tooltip": "Claude Opus 4.5 with extended reasoning",
             "sdkMode": "anthropic",
             "maxInputTokens": 200000,
             "maxOutputTokens": 64000,
@@ -19,7 +19,7 @@
         {
             "id": "claude-sonnet-4-5",
             "name": "Claude Sonnet 4.5",
-            "tooltip": "Claude Sonnet 4.5 - mô hình cân bằng giữa hiệu suất và chi phí",
+            "tooltip": "Claude Sonnet 4.5 - balanced performance and speed",
             "sdkMode": "anthropic",
             "maxInputTokens": 200000,
             "maxOutputTokens": 8192,
@@ -31,7 +31,20 @@
         {
             "id": "claude-sonnet-4-5-thinking",
             "name": "Claude Sonnet 4.5 Thinking",
-            "tooltip": "Claude Sonnet 4.5 với khả năng suy luận mở rộng",
+            "tooltip": "Claude Sonnet 4.5 with extended reasoning",
+            "sdkMode": "anthropic",
+            "maxInputTokens": 200000,
+            "maxOutputTokens": 64000,
+            "includeThinking": true,
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": true
+            }
+        },
+        {
+            "id": "claude-opus-4-6-thinking",
+            "name": "Claude Opus 4.6 Thinking",
+            "tooltip": "Claude Opus 4.6 - most capable with extended reasoning",
             "sdkMode": "anthropic",
             "maxInputTokens": 200000,
             "maxOutputTokens": 64000,
@@ -44,7 +57,7 @@
         {
             "id": "gemini-3-flash",
             "name": "Gemini 3 Flash",
-            "tooltip": "Gemini 3 Flash - mô hình nhanh và hiệu quả",
+            "tooltip": "Gemini 3 Flash - fast and efficient",
             "sdkMode": "anthropic",
             "maxInputTokens": 1000000,
             "maxOutputTokens": 8192,
@@ -54,9 +67,9 @@
             }
         },
         {
-            "id": "gemini-3-pro-high",
-            "name": "Gemini 3 Pro High",
-            "tooltip": "Gemini 3 Pro với chế độ chất lượng cao",
+            "id": "gemini-3.1-pro-high",
+            "name": "Gemini 3.1 Pro High",
+            "tooltip": "Gemini 3.1 Pro - high quality mode",
             "sdkMode": "anthropic",
             "maxInputTokens": 2000000,
             "maxOutputTokens": 32768,
@@ -66,9 +79,9 @@
             }
         },
         {
-            "id": "gemini-3-pro-image",
-            "name": "Gemini 3 Pro Image",
-            "tooltip": "Gemini 3 Pro tối ưu cho xử lý hình ảnh",
+            "id": "gemini-3.1-pro-image",
+            "name": "Gemini 3.1 Pro Image",
+            "tooltip": "Gemini 3.1 Pro - optimised for image processing",
             "sdkMode": "anthropic",
             "maxInputTokens": 2000000,
             "maxOutputTokens": 8192,
@@ -78,9 +91,9 @@
             }
         },
         {
-            "id": "gemini-3-pro-low",
-            "name": "Gemini 3 Pro Low",
-            "tooltip": "Gemini 3 Pro với chế độ tiết kiệm chi phí",
+            "id": "gemini-3.1-pro-low",
+            "name": "Gemini 3.1 Pro Low",
+            "tooltip": "Gemini 3.1 Pro - cost-efficient mode",
             "sdkMode": "anthropic",
             "maxInputTokens": 2000000,
             "maxOutputTokens": 8192,
@@ -92,7 +105,7 @@
         {
             "id": "gpt-oss-120b-medium",
             "name": "GPT OSS 120B Medium",
-            "tooltip": "GPT Open Source 120B - mô hình mã nguồn mở",
+            "tooltip": "GPT Open Source 120B - open-source model",
             "sdkMode": "anthropic",
             "maxInputTokens": 128000,
             "maxOutputTokens": 8192,

--- a/src/status/antigravityStatusBar.ts
+++ b/src/status/antigravityStatusBar.ts
@@ -291,7 +291,7 @@ export class AntigravityStatusBar extends ProviderStatusBarItem<AntigravityQuota
                     if (fraction < geminiMinQuota) {
                         geminiMinQuota = fraction;
                     }
-                    if (modelIdLower.includes('gemini-3-pro')) {
+                    if (modelIdLower.includes('gemini-3.1-pro')) {
                         gemini3ProQuota = fraction;
                     }
                 } else if (modelIdLower.includes('claude')) {


### PR DESCRIPTION
## Summary

Complete fix for the Antigravity (Google Cloud Code) provider. All issues discovered during live testing have been resolved.

## Changes

### Network / Routing
- **Fix `DEFAULT_BASE_URLS`**: Added `daily-cloudcode-pa.googleapis.com` as the primary endpoint — the old list only had sandbox and legacy URLs, causing 404 on all requests
- **Update `DEFAULT_USER_AGENT`** to `antigravity/1.22.2`

### Stream Processing
- **Fix `sdkMode`**: Changed from `'openai'` to `'anthropic'` so requests route to `AntigravityStreamProcessor` instead of `OpenAIStreamProcessor` (which couldn't parse the Gemini-format SSE stream — no output was produced)
- **Add `StreamingStartedError`**: Prevents endpoint-fallback retry after streaming has already started, which would replay tool calls and produce duplicates in the Copilot UI
- **Fix `thinkingTagBuffer` flush**: The tag lookahead buffer could hold up to 10 chars past end of stream; now flushed in the `finally` block before final text flush
- **Add `totalTextEmitted` counter + thought-only fallback**: If the stream ends with zero text emitted but accumulated thinking content (e.g. GPT OSS 120B which returns 100% `thought:true` parts), the thinking content is emitted as a text response instead of showing "Sorry, no response was returned"

### JSON Schema Sanitization
- **Expand `GEMINI_UNSUPPORTED_FIELDS`** in both `handler.ts` and `requestHelpers.ts`: added `const`, `enumDescriptions`, `enumCaseInsensitive`, `enumNormalizeWhitespace`, `default`, `deprecated`, `readOnly`, `writeOnly`, `format`, `cache_control`, `propertyNames` — all sourced from anti-api's json-schema-cleaner; these cause HTTP 400 from the Gemini API

### Model Filtering
- **`fetchModels` / `getCachedModels`**: Models are now filtered to only those returned by the quota API endpoint — unavailable models are hidden. Falls back to full list if the API returns an empty response
- **`tryFetchQuotaFromEndpoint`**: Tracks all models present in the response (not just those with explicit `quotaInfo`) — presence alone indicates availability
- **Fix `setApiKey` ordering** for both new-account and credential-refresh paths: API key (with filtered model list) is now persisted *before* the account-change event fires, so `provideLanguageModelChatInformation` already sees the correct model list
- **Remove `addAllAntigravityModelsToCompatible`** call on login — models are no longer auto-added to the Compatible Provider

### Config & Aliases
- **Update model aliases**: Gemini 3.1 naming (`gemini-3.1-pro-*`), `claude-opus-4-6-thinking`, `gpt-oss-120b` → `gpt-oss-120b-medium`, dot-notation Claude variants
- **Add `claude-opus-4-6-thinking`** to `antigravity.json`
- **Translate tooltip fields** in `antigravity.json` to English
- **Update `baseUrl`** in `antigravity.json` to `daily-cloudcode-pa.googleapis.com/v1internal`

### Version
- Bumped `0.15.27` → `0.16.0`